### PR TITLE
Correct link to Guzzle docs and add version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # PHP + Guzzle Code Generator (Paw Extension)
 
-A [Paw Extension](http://luckymarmot.com/paw/extensions/) that generates PHP code for the [Guzzle](http://guzzle.readthedocs.org/en/latest/) library.
+A [Paw Extension](http://luckymarmot.com/paw/extensions/) that generates PHP code for the [Guzzle](https://guzzle3.readthedocs.io) 3.x library.
 
 ## Installation
 


### PR DESCRIPTION
Guzzle 3.x is now deprecated, 6.x is the current version. There are significant code changes and PAW creates code for Guzzle 3.x. The link pointed to the latest documentation which is 6.x. Corrected link and added the version so users of the extension know which version of Guzzle code this creates.