### PR TITLE
Add Guzzle version number to title

### DIFF
--- a/PHPGuzzleCodeGenerator.coffee
+++ b/PHPGuzzleCodeGenerator.coffee
@@ -130,7 +130,7 @@ PHPGuzzleCodeGenerator = ->
 PHPGuzzleCodeGenerator.identifier =
     "com.luckymarmot.PawExtensions.PHPGuzzleCodeGenerator"
 PHPGuzzleCodeGenerator.title =
-    "PHP (Guzzle)"
+    "PHP (Guzzle 3.x)"
 PHPGuzzleCodeGenerator.fileExtension = "php"
 PHPGuzzleCodeGenerator.languageHighlighter = "php"
 


### PR DESCRIPTION
Put the version of guzzle this extension supports into the title so it shows in the manage extensions UI.